### PR TITLE
Support Marshal `dump` / `load` with frozen object

### DIFF
--- a/lib/data.rb
+++ b/lib/data.rb
@@ -115,6 +115,15 @@ else
 
     private
 
+    def marshal_dump
+      @attributes
+    end
+
+    def marshal_load(attributes)
+      @attributes = attributes
+      freeze
+    end
+
     def initialize_copy(source)
       super.freeze
     end


### PR DESCRIPTION
Using custom `marshal_dump` and `marshal_load` methods to ensure the loaded object is frozen. Since there's no way for the dumped object to not be frozen, the loader is hard-coded to freeze.

Closes #3