### PR TITLE
Improve `#members` performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gem "rake", "~> 13.0"
 
 gem "minitest", "~> 5.0"
 gem "debug"
+gem "benchmark-ips"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    benchmark-ips (2.10.0)
     debug (1.7.1)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
@@ -18,9 +19,10 @@ GEM
       io-console (~> 0.5)
 
 PLATFORMS
-  ruby
+  arm64-darwin-21
 
 DEPENDENCIES
+  benchmark-ips
   debug
   minitest (~> 5.0)
   polyfill-data!

--- a/bench.rb
+++ b/bench.rb
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "polyfill-data"
+require "benchmark/ips"
+
+puts RUBY_DESCRIPTION
+
+data = Data.define(:a, :b, :c)
+
+Benchmark.ips do |x|
+	x.report(".define") { Data.define(:a, :b, :c) }
+	x.report("#members") { data.members }
+end

--- a/lib/data.rb
+++ b/lib/data.rb
@@ -9,6 +9,7 @@ else
   class Data < Object
     class << self
       undef_method :new
+      attr_reader :members
     end
 
     def self.define(*args, &block)
@@ -20,7 +21,7 @@ else
         Data.const_set(name, klass)
       end
 
-      klass.define_singleton_method(:members) { args.map{ _1.intern } }
+      klass.instance_variable_set(:@members, args)
 
       klass.define_singleton_method(:new) do |*new_args, **new_kwargs, &block|
         init_kwargs = if new_args.any?


### PR DESCRIPTION
Improve `#members` performance by ~4× at a small cost to `.define`.

Before
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
             .define    20.855k i/100ms
            #members   462.221k i/100ms
Calculating -------------------------------------
             .define    207.029k (± 2.5%) i/s -      1.043M in   5.039794s
            #members      4.615M (± 0.7%) i/s -     23.111M in   5.008104s
```

After
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
             .define    21.214k i/100ms
            #members     1.818M i/100ms
Calculating -------------------------------------
             .define    210.958k (± 2.3%) i/s -      1.061M in   5.030760s
            #members     18.104M (± 0.2%) i/s -     90.911M in   5.021470s
```