### PR TITLE
Use `each` instead of `map`

### DIFF
--- a/lib/data.rb
+++ b/lib/data.rb
@@ -48,7 +48,7 @@ else
         undef_method :define
       end
 
-      args.map do |arg|
+      args.each do |arg|
         if klass.method_defined?(arg)
           raise ArgumentError, "duplicate member #{arg}"
         end


### PR DESCRIPTION
`map` allocates extra array so when we don't need it we can use `each` for better performance.